### PR TITLE
Removed part of patch + Added better setChargingProfile script

### DIFF
--- a/demo-scripts/TXProfile_1.json
+++ b/demo-scripts/TXProfile_1.json
@@ -1,0 +1,23 @@
+{
+    "id": 1,
+    "chargingProfileKind": "Absolute",
+    "chargingProfilePurpose": "TxDefaultProfile",
+    "chargingSchedule": [
+        {
+            "id": 0,
+            "chargingRateUnit": "A",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 20.0,
+                    "numberPhases": 1,
+                    "startPeriod": 0
+                }
+            ],
+            "duration": 86400,
+            "minChargingRate": 0.0,
+            "startSchedule": "2024-06-13T00:00:00.000Z"
+        }
+    ],
+    "recurrencyKind": "Daily",
+    "stackLevel": 1
+}

--- a/demo-scripts/maeve-set-charging-profile.sh
+++ b/demo-scripts/maeve-set-charging-profile.sh
@@ -1,18 +1,13 @@
 #!/bin/bash
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <chargingStation>"
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <chargingStation> <jsonFile>"
   exit 1
 fi
 
 CS=$1
-
-echo "setChargingProfile called with Charging Station: ${CS}"
-
-curl -X POST \
-  "http://localhost:9410/api/v0/cs/${CS}/setchargingprofile" \
-  -H "Content-Type: application/json" \
-  -d '{
+JSON_FILE=$2
+JSON_DATA='{
     "chargingProfileKind": "Absolute",
     "chargingProfilePurpose": "TxProfile",
     "chargingSchedule": [
@@ -64,3 +59,19 @@ curl -X POST \
     "validFrom": "2024-06-07T10:00:00Z",
     "validTo": "2024-06-07T18:00:00Z"
   }'
+
+# Read JSON file and do some error handling
+if [ -n "$JSON_FILE" ]; then
+  if [ ! -f "$JSON_FILE" ]; then
+    echo "Error: JSON file '$JSON_FILE' not found!"
+    exit 1
+  fi
+  JSON_DATA=$(cat "$JSON_FILE")
+fi
+
+echo "setChargingProfile called with Charging Station: ${CS}"
+
+curl -X POST \
+  "http://localhost:9410/api/v0/cs/${CS}/setchargingprofile" \
+  -H "Content-Type: application/json" \
+  -d "$JSON_DATA"

--- a/manager/libocpp.patch
+++ b/manager/libocpp.patch
@@ -63,34 +63,3 @@ diff -r -uw libocpp_unmod/lib/ocpp/v201/charge_point.cpp libocpp/lib/ocpp/v201/c
      this->send<SetChargingProfileResponse>(call_result);
  }
 Only in libocpp/lib/ocpp/v201: charge_point.cpp.orig
-diff -r -uw libocpp_unmod/lib/ocpp/v201/messages/SetChargingProfile.cpp libocpp/lib/ocpp/v201/messages/SetChargingProfile.cpp
---- libocpp_unmod/lib/ocpp/v201/messages/SetChargingProfile.cpp	2024-06-11 14:29:41
-+++ libocpp/lib/ocpp/v201/messages/SetChargingProfile.cpp	2024-06-12 12:25:48
-@@ -7,6 +7,15 @@
- #include <optional>
- 
- #include <ocpp/v201/messages/SetChargingProfile.hpp>
-+#include <ocpp/common/types.hpp>
-+#include <ocpp/v201/charge_point.hpp>
-+#include <ocpp/v201/ctrlr_component_variables.hpp>
-+#include <ocpp/v201/device_model_storage_sqlite.hpp>
-+#include <ocpp/v201/enums.hpp>
-+#include <ocpp/v201/messages/FirmwareStatusNotification.hpp>
-+#include <ocpp/v201/messages/LogStatusNotification.hpp>
-+#include <ocpp/v201/notify_report_requests_splitter.hpp>
-+#include <ocpp/v201/smart_charging.hpp>
- 
- using json = nlohmann::json;
- 
-@@ -31,8 +40,9 @@
- 
- void from_json(const json& j, SetChargingProfileRequest& k) {
-     // the required parts of the message
--    k.evseId = j.at("evseId");
--    k.chargingProfile = j.at("chargingProfile");
-+    EVLOG_error << "In the message class, parsing from JSON: " << j;
-+    k.evseId = j.value("evseId", 1);
-+    k.chargingProfile = j.value("chargingProfile", j.at("ChargingProfile"));
- 
-     // the optional parts of the message
-     if (j.contains("customData")) {


### PR DESCRIPTION
Got rid of part of patch because `setChargingProfile` implementation now works, and changed the `setChargingProfile` script.

**Testing Done**
- Ran `bash demo-iso15118-2-ac-plus-ocpp.sh -r $(pwd) -b remove_patch -3` and observed everything working correctly. All containers started, SIL demo worked, and `setChargingProfile` worked.